### PR TITLE
[AI] Calendar: fix EAS 16.x recurrence exceptions (duplicate/stray occurrences) and clean cancelled titles

### DIFF
--- a/content/includes/calendarsync.js
+++ b/content/includes/calendarsync.js
@@ -264,6 +264,18 @@ var Calendar = {
         if (tbStatus) item.setProperty("STATUS", tbStatus)
         else item.deleteProperty("STATUS");
 
+        // Exchange prepends a localized "Canceled: " to the Subject of a cancelled
+        // meeting (or cancelled occurrence of a recurring series). That word is
+        // redundant with STATUS=CANCELLED - which already renders the item
+        // struck-through - and, because it is baked into the stored title, it
+        // lingers even after the occurrence is reactivated or moved. Strip it so a
+        // cancelled item shows a clean, struck-through title, matching CalDAV/Google.
+        // (Handles the English "Canceled:"/"Cancelled:" prefix; other UI locales
+        // would need their localized word added here.)
+        if (tbStatus == "CANCELLED" && item.title) {
+            item.title = item.title.replace(/^\s*cancell?ed:\s*/i, "");
+        }
+
         // If this was an incoming exception, properly register it on the master
         if (item._isIncomingException) {
             let master = tbItem instanceof TbSync.lightning.TbItem ? tbItem.nativeItem : tbItem;

--- a/content/includes/sync.js
+++ b/content/includes/sync.js
@@ -1345,8 +1345,16 @@ var sync = {
                 // Exception could be an object or an array of objects
                 let exceptions = [].concat(data.Exceptions.Exception);
                 for (let exception of exceptions) {
-                    //exception.ExceptionStartTime is in UTC, but the Recurrence Object is in local timezone
-                    let dateTime = TbSync.lightning.cal.createDateTime(exception.ExceptionStartTime).getInTimezone(timezone);
+                    // The occurrence being overridden is identified by InstanceId in
+                    // EAS 16.x (AirSyncBase namespace) and by ExceptionStartTime in
+                    // older protocol versions (2.5/14.x). Both are UTC, while the
+                    // Recurrence object is in the local timezone. Without the
+                    // InstanceId fallback, 16.x exceptions - which only send InstanceId -
+                    // resolved to an undefined date, so the original occurrence was
+                    // never overridden/removed and moved or cancelled occurrences
+                    // showed up as duplicate/stray items.
+                    let originalInstance = exception.InstanceId || exception.ExceptionStartTime;
+                    let dateTime = TbSync.lightning.cal.createDateTime(originalInstance).getInTimezone(timezone);
                     if (data.AllDayEvent == "1") {
                         dateTime.isDate = true;
                         // Pass to replacement event unless overriden


### PR DESCRIPTION
## Summary
Fixes two related problems with recurring calendar events synced from Exchange via EAS 16.x:
a moved/cancelled/deleted occurrence produced a **duplicate or stray extra event**, and
cancelled occurrences showed a redundant `Canceled: ` word in the title instead of just being
struck through.

## Root cause (the main fix)
Recurrence exceptions embedded in a series master (`<Recurrence>` → `<Exceptions>`) were matched
to the occurrence they override using `exception.ExceptionStartTime`. That field only exists in
**EAS 2.5 / 14.x**. **EAS 16.x** sends the instance identifier as **`InstanceId`** (AirSyncBase
namespace), so `ExceptionStartTime` was `undefined`, the override resolved to a bogus date, and
the original occurrence was never moved/removed/cancelled. The change then surfaced as a separate
item — e.g. a rescheduled occurrence appearing at **both** its old and new time.

Real example (from a debug log): a weekly meeting occurrence moved from 08:45 to 09:00 showed up
**two** times on the affected day in Thunderbird while Outlook/OWA correctly showed one.

## Changes
- **`content/includes/sync.js`** (`setItemRecurrence`): identify the overridden occurrence via
  `exception.InstanceId`, falling back to `exception.ExceptionStartTime` for older servers. This
  fixes moved, cancelled, and deleted occurrences (the `Deleted` and `modifyException` paths all
  used the same bad date).
- **`content/includes/calendarsync.js`** (`setThunderbirdItemFromWbxml`): when an occurrence is
  cancelled, strip the localized `Canceled:`/`Cancelled:` prefix Exchange adds to the Subject, so
  the item shows a clean, struck-through title (`STATUS=CANCELLED`) instead of the redundant word —
  matching CalDAV/Google behaviour. (English prefix only; other UI locales would need their word
  added.)

## Testing
Validated live on Thunderbird 153 against an Exchange/Office 365 account:
- A rescheduled recurring occurrence now shows **once**, at its new time (no stray duplicate).
- A cancelled occurrence shows **struck-through with a clean title**.
- Deleted occurrences are correctly removed from the series.

Note: existing already-synced items need a one-time re-download of the calendar (uncheck → sync →
re-check → sync in TbSync) to re-process with the corrected exception handling.

## Notes
- The attached test XPI also bundles the TB153 `searchLoginsAsync` fix (#8) for convenience, so it
  can be tested on TB153 as a single add-on. It still requires the patched TbSync core build.
