### PR TITLE
[AI] TB153 OAuth fixes: EAS.AccessAsUser.All scope + refresh expired tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
-# EAS-4-TbSync
+# EAS-4-TbSync (NielBuys fork)
+
+> ### 🍴 About this fork
+>
+> A maintained fork of [jobisoft/EAS-4-TbSync](https://github.com/jobisoft/EAS-4-TbSync).
+>
+> **Purpose:** keep an up-to-date, **working** Exchange ActiveSync (EAS) provider — together with the TbSync core it runs on — functioning on current Thunderbird releases (Thunderbird 153+), with EAS 16.1 support.
+>
+> **Requires the matching TbSync core fork:** [NielBuys/TbSync](https://github.com/NielBuys/TbSync). Install **both** — this EAS provider relies on TB153 fixes that live in the forked TbSync core, so it will not work correctly on top of upstream TbSync on newer Thunderbird versions.
 
 ## Exchange Active Sync (EAS) protocol v 16.1 Initial Support
 
 Initial support for protocol version 16.1 introduced in this version:
 - Calendar/Contacts/Tasks editing and synchronization is working
 
-Not implemented:
+## Known limitations
 
-- Calendar: accepting/rejecting invitations
-  
+- **Accepting / rejecting meeting invitations does not notify the organizer.** The **Accept / Tentative / Decline** buttons on a calendar invitation do not send an RSVP back to the Exchange server (the EAS `MeetingResponse` command is not implemented yet). Clicking them may update the event locally, but the organizer is **not** informed of your response. To reply, use Outlook / Outlook Web for now. This is a planned feature.
+
 
 I your server supports EAS v14 (Exchange 2016/2019/SE(?)) the add-on will autoselect EAS v16.1 protocol version whenever available.
 

--- a/content/includes/network.js
+++ b/content/includes/network.js
@@ -197,9 +197,13 @@ var network = {
 
         switch (host) {
             case "outlook.office365.com":
-                config.scope = "offline_access https://outlook.office.com/.default";
-                break;
             case "eas.outlook.com":
+                // Use the resource-specific EAS scope for both hosts. Requesting the
+                // ".default" scope triggered AADSTS70011 (".default scope can't be
+                // combined with resource-specific scopes") once Thunderbird's OAuth
+                // layer merged it with the EAS.AccessAsUser.All scope the tenant
+                // grants. Dropping ".default" leaves an all-resource-specific request,
+                // which Microsoft accepts.
                 config.scope = "offline_access https://outlook.office.com/EAS.AccessAsUser.All";
                 break;
         }

--- a/content/includes/network.js
+++ b/content/includes/network.js
@@ -247,10 +247,16 @@ var network = {
             oauth.refreshToken = await oauth.getToken("refreshToken");
             oauth.tokenExpires = await oauth.getToken("tokenExpires");
 
+            // Force a real token refresh when there is no access token or the
+            // current one is (about to be) expired. Passing refresh=false let
+            // OAuth2.connect() early-return on a stale-but-present token whose
+            // module-side expiry tracking reads as valid, so Thunderbird kept
+            // sending a dead token until Microsoft returned 401 invalid_token
+            // (the "works ~1h then stops until account recreate" symptom).
+            let forceRefresh = !oauth.accessToken || (await oauth.isExpired());
+
             try {
-                // refresh = false will do nothing and resolve immediately, if
-                // a valid accessToken exists.
-                await oauth.connect(/* with UI */ true, /* refresh */ false);
+                await oauth.connect(/* with UI */ true, /* refresh */ forceRefresh);
             } catch (e) {
                 rv.error = eas.tools.isString(e) ? e : JSON.stringify(e);
             }
@@ -291,7 +297,14 @@ var network = {
 
         oauth.isExpired = async function () {
             const OAUTH_GRACE_TIME = 30 * 1000;
-            return ((await oauth.getToken("tokenExpires")) - OAUTH_GRACE_TIME < new Date().getTime());
+            // Prefer the real expiry embedded in the access token (JWT `exp`).
+            // The separately-stored tokenExpires can read as "never expires" on
+            // TB153, which caused expired tokens to be sent until a 401. Fall
+            // back to the stored value only if the token cannot be decoded.
+            let accessToken = await oauth.getToken("accessToken");
+            let jwtExpiry = eas.network.getTokenExpiryMs(accessToken);
+            let tokenExpires = jwtExpiry || (await oauth.getToken("tokenExpires"));
+            return (tokenExpires - OAUTH_GRACE_TIME < new Date().getTime());
         };
 
         const OAUTHVALUES = [
@@ -361,6 +374,23 @@ var network = {
         }
 
         return oauth;
+    },
+
+    // Returns the real expiry (ms since epoch) from a JWT access token's `exp`
+    // claim, or 0 if it cannot be determined. This is the authoritative expiry
+    // source: the separately-stored tokenExpires is unreliable on TB153 (it
+    // defaults to Number.MAX_VALUE whenever an expires_in is missed), which
+    // left expired tokens in use until Microsoft returned 401 invalid_token.
+    getTokenExpiryMs: function (accessToken) {
+        try {
+            if (!accessToken || accessToken.indexOf(".") == -1) return 0;
+            let payload = accessToken.split(".")[1].replace(/-/g, "+").replace(/_/g, "/");
+            while (payload.length % 4) payload += "=";
+            let claims = JSON.parse(atob(payload));
+            return claims.exp ? claims.exp * 1000 : 0;
+        } catch (e) {
+            return 0;
+        }
     },
 
     getOAuthValue: function (currentTokenString, type = "access") {

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
   },
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "4.17.6",
+  "version": "4.17.7",
   "author": "John Bieling",
   "homepage_url": "https://github.com/NielBuys/EAS-4-TbSync",
   "default_locale": "en-US",

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
   },
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "4.17.5",
+  "version": "4.17.6",
   "author": "John Bieling",
   "homepage_url": "https://github.com/NielBuys/EAS-4-TbSync",
   "default_locale": "en-US",


### PR DESCRIPTION
This PR bundles two related **Thunderbird 153** OAuth fixes for Office 365 (EAS) accounts. Both are needed to keep OAuth accounts syncing on TB153.

> ⚠️ The token-refresh fix (Fix 2) also depends on a companion change in TbSync core — see **NielBuys/TbSync#5 (v4.16.6)**. Install both together.

---

## Fix 1 — Scope: request `EAS.AccessAsUser.All` instead of `.default` (AADSTS70011)

### Problem
OAuth sign-in for Office 365 (EAS) accounts fails with:

> AADSTS70011: ... The scope `https://outlook.office.com/EAS.AccessAsUser.All https://outlook.office.com/.default offline_access` is not valid. `.default` scope can't be combined with resource-specific scopes.

The provider requested the `.default` scope for `outlook.office365.com`, but Thunderbird's OAuth layer merges in the resource-specific `https://outlook.office.com/EAS.AccessAsUser.All` scope the tenant actually grants. Microsoft rejects a request that mixes `.default` with resource-specific scopes.

### Fix
Request `https://outlook.office.com/EAS.AccessAsUser.All` for **both** `outlook.office365.com` and `eas.outlook.com`, dropping `.default`. The request is then all-resource-specific (which Microsoft accepts) and matches the scope the tenant grants anyway.

---

## Fix 2 — Refresh expired access tokens instead of resending them (401 `invalid_token`)

### Problem
After the scope fix, a second failure remained on TB153: sync worked for ~1 hour, then stopped with HTTP 401 (`WWW-Authenticate: ... error="invalid_token"`). The account only recovered if it was deleted and re-added. Diagnostics showed the access token being sent was long expired (`exp` ~75 min in the past) and never refreshed.

### Cause & Fix
Two parts, both in [network.js](content/includes/network.js):

- **`isExpired()`** relied on the separately-stored `tokenExpires`, which TB's `OAuth2.sys.mjs` can leave at `Number.MAX_VALUE` ("never expires") — so the expired token was never detected. It now reads the real expiry from the access token's JWT `exp` claim (`getTokenExpiryMs`), falling back to the stored value only if the token can't be decoded.
- **`asyncConnect()`** always called `OAuth2.connect(withUI, /*refresh*/ false)`, letting `connect()` early-return on a stale-but-present token. It now passes `refresh=true` when the token is missing/expired, forcing a real `refresh_token` grant.

(On TB153 the refreshed token also has to be *persisted* through the login manager, which required the async-API fix in TbSync#5. Without that, the refresh succeeded but the new token was silently dropped.)

---

## Testing
Verified live on TB153: fresh consent succeeds, sync works, and the account now **self-heals across the token-expiry boundary** — at expiry it silently refreshes, persists the new token, and keeps syncing, with no 401 and no account recreate. Also verified consent still works on TB140. Requires **TbSync ≥ 4.16.6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
