### PR TITLE
Private fork add-on ID (eas4tbsync@nielbuys.fork) to stop ATN reverting to upstream

### DIFF
--- a/api/EAS4TbSync/implementation.js
+++ b/api/EAS4TbSync/implementation.js
@@ -16,7 +16,7 @@
   async function observeTbSyncInitialized(aSubject, aTopic, aData) {
     try {
       const tbsyncExtension = ExtensionParent.GlobalManager.getExtension(
-        "tbsync@jobisoft.de"
+        "tbsync@nielbuys.fork"
       );
       const { TbSync } = ChromeUtils.importESModule(
         `chrome://tbsync/content/tbsync.sys.mjs?${tbsyncExtension.manifest.version}`
@@ -24,7 +24,7 @@
       // Load this provider add-on into TbSync
       if (TbSync.enabled) {
         const easExtension = ExtensionParent.GlobalManager.getExtension(
-          "eas4tbsync@jobisoft.de"
+          "eas4tbsync@nielbuys.fork"
         );
         console.log(`Registering EAS provider v${easExtension.manifest.version} with TbSync v${tbsyncExtension.manifest.version}`);
         await TbSync.providers.loadProvider(easExtension, "eas", "chrome://eas4tbsync/content/provider.js");
@@ -59,7 +59,7 @@
       //unload this provider add-on from TbSync
       try {
         const tbsyncExtension = ExtensionParent.GlobalManager.getExtension(
-          "tbsync@jobisoft.de"
+          "tbsync@nielbuys.fork"
         );
         const { TbSync } = ChromeUtils.importESModule(
           `chrome://tbsync/content/tbsync.sys.mjs?${tbsyncExtension.manifest.version}`

--- a/content/includes/calendarsync.js
+++ b/content/includes/calendarsync.js
@@ -21,7 +21,7 @@ var { ExtensionParent } = ChromeUtils.importESModule(
 );
 
 var tbsyncExtension = ExtensionParent.GlobalManager.getExtension(
-    "tbsync@jobisoft.de"
+    "tbsync@nielbuys.fork"
 );
 var { TbSync } = ChromeUtils.importESModule(
     `chrome://tbsync/content/tbsync.sys.mjs?${tbsyncExtension.manifest.version}`

--- a/content/includes/contactsync.js
+++ b/content/includes/contactsync.js
@@ -25,7 +25,7 @@ var { MailServices } = ChromeUtils.importESModule(
 );
 
 var tbsyncExtension = ExtensionParent.GlobalManager.getExtension(
-    "tbsync@jobisoft.de"
+    "tbsync@nielbuys.fork"
 );
 var { TbSync } = ChromeUtils.importESModule(
     `chrome://tbsync/content/tbsync.sys.mjs?${tbsyncExtension.manifest.version}`

--- a/content/includes/network.js
+++ b/content/includes/network.js
@@ -16,7 +16,7 @@ var { OAuth2 } = ChromeUtils.importESModule(
 );
 
 var tbsyncExtension = ExtensionParent.GlobalManager.getExtension(
-    "tbsync@jobisoft.de"
+    "tbsync@nielbuys.fork"
 );
 var { TbSync } = ChromeUtils.importESModule(
     `chrome://tbsync/content/tbsync.sys.mjs?${tbsyncExtension.manifest.version}`

--- a/content/includes/sync.js
+++ b/content/includes/sync.js
@@ -13,7 +13,7 @@ var { ExtensionParent } = ChromeUtils.importESModule(
 );
 
 var tbsyncExtension = ExtensionParent.GlobalManager.getExtension(
-    "tbsync@jobisoft.de"
+    "tbsync@nielbuys.fork"
 );
 var { TbSync } = ChromeUtils.importESModule(
     `chrome://tbsync/content/tbsync.sys.mjs?${tbsyncExtension.manifest.version}`

--- a/content/includes/tasksync.js
+++ b/content/includes/tasksync.js
@@ -13,7 +13,7 @@ var { ExtensionParent } = ChromeUtils.importESModule(
 );
 
 var tbsyncExtension = ExtensionParent.GlobalManager.getExtension(
-    "tbsync@jobisoft.de"
+    "tbsync@nielbuys.fork"
 );
 var { TbSync } = ChromeUtils.importESModule(
     `chrome://tbsync/content/tbsync.sys.mjs?${tbsyncExtension.manifest.version}`

--- a/content/includes/tools.js
+++ b/content/includes/tools.js
@@ -19,7 +19,7 @@ var { NetUtil } = ChromeUtils.importESModule(
 );
 
 var tbsyncExtension = ExtensionParent.GlobalManager.getExtension(
-    "tbsync@jobisoft.de"
+    "tbsync@nielbuys.fork"
 );
 var { TbSync } = ChromeUtils.importESModule(
     `chrome://tbsync/content/tbsync.sys.mjs?${tbsyncExtension.manifest.version}`

--- a/content/includes/wbxmltools.js
+++ b/content/includes/wbxmltools.js
@@ -13,7 +13,7 @@ var { ExtensionParent } = ChromeUtils.importESModule(
 );
 
 var tbsyncExtension = ExtensionParent.GlobalManager.getExtension(
-    "tbsync@jobisoft.de"
+    "tbsync@nielbuys.fork"
 );
 var { TbSync } = ChromeUtils.importESModule(
     `chrome://tbsync/content/tbsync.sys.mjs?${tbsyncExtension.manifest.version}`

--- a/content/includes/xmltools.js
+++ b/content/includes/xmltools.js
@@ -13,7 +13,7 @@ var { ExtensionParent } = ChromeUtils.importESModule(
 );
 
 var tbsyncExtension = ExtensionParent.GlobalManager.getExtension(
-    "tbsync@jobisoft.de"
+    "tbsync@nielbuys.fork"
 );
 var { TbSync } = ChromeUtils.importESModule(
     `chrome://tbsync/content/tbsync.sys.mjs?${tbsyncExtension.manifest.version}`

--- a/content/locales.js
+++ b/content/locales.js
@@ -3,7 +3,7 @@ var { ExtensionParent } = ChromeUtils.importESModule(
 );
 
 var tbsyncExtension = ExtensionParent.GlobalManager.getExtension(
-    "tbsync@jobisoft.de"
+    "tbsync@nielbuys.fork"
 );
 var { TbSync } = ChromeUtils.importESModule(
     `chrome://tbsync/content/tbsync.sys.mjs?${tbsyncExtension.manifest.version}`

--- a/content/manager/createAccount.js
+++ b/content/manager/createAccount.js
@@ -13,7 +13,7 @@ var { ExtensionParent } = ChromeUtils.importESModule(
 );
 
 var tbsyncExtension = ExtensionParent.GlobalManager.getExtension(
-    "tbsync@jobisoft.de"
+    "tbsync@nielbuys.fork"
 );
 var { TbSync } = ChromeUtils.importESModule(
     `chrome://tbsync/content/tbsync.sys.mjs?${tbsyncExtension.manifest.version}`

--- a/content/provider.js
+++ b/content/provider.js
@@ -16,7 +16,7 @@ var { MailServices } = ChromeUtils.importESModule(
 );
 
 var tbsyncExtension = ExtensionParent.GlobalManager.getExtension(
-    "tbsync@jobisoft.de"
+    "tbsync@nielbuys.fork"
 );
 var { TbSync } = ChromeUtils.importESModule(
     `chrome://tbsync/content/tbsync.sys.mjs?${tbsyncExtension.manifest.version}`

--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,14 @@
 {
   "applications": {
     "gecko": {
-      "id": "eas4tbsync@jobisoft.de",
+      "id": "eas4tbsync@nielbuys.fork",
       "strict_min_version": "136.0",
       "strict_max_version": "160.*"
     }
   },
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "4.17.7",
+  "version": "4.17.8",
   "author": "John Bieling",
   "homepage_url": "https://github.com/NielBuys/EAS-4-TbSync",
   "default_locale": "en-US",


### PR DESCRIPTION
## Problem

A reporter on Thunderbird 140 kept hitting `AADSTS70011` / 401 `invalid_token` (works ~1h after re-adding the account, then dies) — even with this fork installed. Their log registers the EAS provider **twice**:

```
Registering EAS provider v4.17.7 with TbSync v4.16.6   <- this fork (sideloaded)
Registering EAS provider v4.18   with TbSync v4.16.6   <- upstream, overrides it
```

Root cause: this fork shared upstream's add-on ID `eas4tbsync@jobisoft.de` and sat **below** upstream's version. addons.thunderbird.net auto-updated the install onto upstream **v4.18**, which still requests the `.default` OAuth scope for `outlook.office365.com`. On token refresh, Thunderbird merges the tenant-granted `EAS.AccessAsUser.All` with `.default` → `AADSTS70011` (".default can't be combined with resource-specific scopes"). It is *not* a TB140-vs-TB153 issue — the machine was simply running upstream code.

Because upstream is now on a v5 line, a version race is unwinnable.

## Fix

Give the fork its **own add-on ID** so ATN can never touch it:

- `eas4tbsync@jobisoft.de` → **`eas4tbsync@nielbuys.fork`** (manifest + the self-lookup in `implementation.js`)
- All TbSync core lookups `tbsync@jobisoft.de` → **`tbsync@nielbuys.fork`** (pairs with the TbSync core fork PR)

The new ID preserves the `{provider}4{coreId}` convention (`eas4` + `tbsync@nielbuys.fork`), so TbSync's `DOMOverlayLoaded_<id>` event naming still matches — no logic change. **No Microsoft/Azure change**: the OAuth `client_id` is unchanged, so no app re-registration/consent reset.

Version up **4.17.8**.

## Rollout (per machine)

Uninstall the old EAS **and** old TbSync add-ons, install the fork builds (`eas4tbsync-4.17.8` + `tbsync-4.16.8`), **restart Thunderbird**, then delete/re-add the Office 365 account once.

No need to disable automatic updates: with a private add-on ID (not listed on ATN) and no `update_url` in the manifest, Thunderbird has no update source for these builds — they are never auto-updated.

> Requires the matching TbSync core fork PR (id `tbsync@nielbuys.fork`, v4.16.8). Install both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)