### PR TITLE
[AI] Implement EAS MeetingResponse for invitation Accept/Decline/Tentative

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ Invitations received after the upgrade are unaffected.
 ### Known limitations
 
 - **EAS 2.5 cannot answer a single occurrence** — the protocol has no `InstanceId` for `MeetingResponse`. The response is not sent and the event log says so, rather than answering the whole series behind your back. Use a newer ActiveSync version, or respond in Outlook.
-- **Answering from the invitation e-mail** can leave a duplicate event in your calendar. Thunderbird's own iTIP handling records the response in a second, local copy of the event instead of the copy TbSync synced. That copy is detected and is *not* pushed to the server — your response is sent for the synced event, and the TbSync event log says so — but the stray local copy is left in place. Delete it manually if the event shows up twice.
+- **Answering from the invitation e-mail** makes Thunderbird record the response in a second, local copy of the event rather than the copy TbSync synced. That copy is detected and never pushed to the server — your response is sent for the synced event instead, so the meeting is not duplicated and the other attendees are not re-invited. When the duplicate can be matched exactly, by the invitation UID, it is removed automatically. When it can only be matched by subject and time it is left in your calendar, because deleting on a heuristic is not worth the risk — delete it yourself if the event shows up twice. Either way the TbSync event log records what happened.
+
+  Note that the organizer is notified **once**, by Thunderbird's own iTIP reply. The EAS command sends no email of its own (see [How the organizer gets told](#how-the-organizer-gets-told)), so answering from the e-mail does not double-notify.
 - **Editing a received invitation while responding to it** in the same sync interval sends only the response; the other edits are not pushed. Exchange does not accept item edits from attendees anyway.
 
 ## Reporting problems

--- a/README.md
+++ b/README.md
@@ -45,9 +45,20 @@ Calendar, contacts and task synchronization and editing work on 16.1. The protoc
 
 ## Meeting invitations (RSVP)
 
-**Accept / Tentative / Decline** on a received calendar invitation is sent back to the server with the EAS `MeetingResponse` command, so the organizer and the other attendees see your response. This works both for a whole meeting and for a **single occurrence** of a recurring one — answering one occurrence answers only that occurrence, matching Outlook.
+**Accept / Tentative / Decline** on a received calendar invitation is sent back to the server with the EAS `MeetingResponse` command, so your participation status is recorded server-side and stays correct across all your devices. This works both for a whole meeting and for a **single occurrence** of a recurring one — answering one occurrence answers only that occurrence, matching Outlook.
 
 Previously the changed attendee status was pushed as an ordinary item change. Exchange interpreted that as *you* creating a new, self-organized meeting — duplicating the event and re-inviting everybody — and for a recurring meeting it silently did nothing at all. A freshly received, unanswered invitation is also no longer shown as already accepted (`ResponseType`/`AttendeeStatus` value `5` means *not responded*, not *accepted*).
+
+### How the organizer gets told
+
+Two separate mechanisms are involved, and it is worth knowing which does what:
+
+- **The EAS `MeetingResponse` command** (this add-on) records your status on the server. It does **not** send any email: on protocol 16.x an email is only sent if the request carries a `SendResponse` element, and we deliberately omit it.
+- **Thunderbird's own iTIP handling** emails the organizer a reply ("Accepted: …") over SMTP, using the identity bound to the calendar. TbSync sets that identity on EAS calendars, so this happens on its own whenever you change your participation status.
+
+`SendResponse` is omitted **on purpose**: Thunderbird already sends the reply, so adding it would make Exchange send a second one and notify the organizer twice for every response. Please do not "fix" this by adding it.
+
+Whether the organizer's client then shows you as accepted depends on it processing that reply — which is out of this add-on's hands. Personal Outlook.com accounts in particular do not reliably fold an iTIP reply from an external domain into their attendee tracking.
 
 ### After upgrading from 4.17.x or earlier
 

--- a/README.md
+++ b/README.md
@@ -1,41 +1,88 @@
 # EAS-4-TbSync (NielBuys fork)
 
+Adds Microsoft **Exchange ActiveSync** (EAS) synchronization — calendars, contacts and tasks — to [TbSync](https://github.com/jobisoft/TbSync/) in Thunderbird.
+
 > ### 🍴 About this fork
 >
 > A maintained fork of [jobisoft/EAS-4-TbSync](https://github.com/jobisoft/EAS-4-TbSync).
 >
-> **Purpose:** keep an up-to-date, **working** Exchange ActiveSync (EAS) provider — together with the TbSync core it runs on — functioning on current Thunderbird releases (Thunderbird 153+), with EAS 16.1 support.
+> **Purpose:** keep a **working** EAS provider — together with the TbSync core it runs on — functioning on current Thunderbird releases, and keep EAS 16.1 usable now that Exchange Online has retired EAS 14.
 >
-> **Requires the matching TbSync core fork:** [NielBuys/TbSync](https://github.com/NielBuys/TbSync). Install **both** — this EAS provider relies on TB153 fixes that live in the forked TbSync core, so it will not work correctly on top of upstream TbSync on newer Thunderbird versions.
+> **Requires the matching TbSync core fork:** [NielBuys/TbSync](https://github.com/NielBuys/TbSync). Install **both** — this provider relies on fixes that live in the forked core, so it will not work correctly on top of upstream TbSync on newer Thunderbird versions.
+>
+> Both forks use their own add-on IDs (`eas4tbsync@nielbuys.fork` / `tbsync@nielbuys.fork`) so that addons.thunderbird.net cannot silently replace them with the upstream versions.
 
-## Exchange Active Sync (EAS) protocol v 16.1 Initial Support
+## Requirements
 
-Initial support for protocol version 16.1 introduced in this version:
-- Calendar/Contacts/Tasks editing and synchronization is working
+| | |
+|---|---|
+| Thunderbird | 136 – 160 |
+| TbSync core | [NielBuys/TbSync](https://github.com/NielBuys/TbSync) fork |
+| Server | Exchange (on-premises or Exchange Online / Microsoft 365), or another EAS-compatible server such as Z-Push / Kopano or Horde |
 
-## Known limitations
+## Installing
 
-- **Accepting / rejecting meeting invitations does not notify the organizer.** The **Accept / Tentative / Decline** buttons on a calendar invitation do not send an RSVP back to the Exchange server (the EAS `MeetingResponse` command is not implemented yet). Clicking them may update the event locally, but the organizer is **not** informed of your response. To reply, use Outlook / Outlook Web for now. This is a planned feature.
+Both add-ons are installed from file — they are not on addons.thunderbird.net.
 
+1. Download the `.xpi` for the **TbSync core fork** and for this **EAS provider**.
+2. In Thunderbird: *Add-ons and Themes* → gear icon → *Install Add-on From File…* → pick the TbSync core XPI first, then this one.
+3. Restart Thunderbird, then open *Tools → Synchronization Settings (TbSync)* and add an Exchange ActiveSync account.
 
-I your server supports EAS v14 (Exchange 2016/2019/SE(?)) the add-on will autoselect EAS v16.1 protocol version whenever available.
+## Protocol version support
 
-This can be changed to desired version in 'Account Settings' in TbSync account manager.
+EAS **2.5**, **14.0** and **16.1** are supported. The version is chosen per account in *TbSync account settings → ActiveSync version*:
 
-([EAS protocol v 14 support for Exchange Online ends on 01.03.2026](https://techcommunity.microsoft.com/blog/exchange/exchange-online-activesync-device-support-update/4477997))
+- **Autodetect** (default) queries the server and picks the first version it offers, in the order **14.0 → 16.1 → 2.5**. So a server that still offers EAS 14 will be used with 14.0; 16.1 is selected when 14.0 is no longer offered — which is the case for Exchange Online.
+- Any of **v2.5 / v14.0 / v16.1** can be selected explicitly. Sync fails with a clear error if the server does not advertise the version you picked.
 
-This provider add-on adds Exchange ActiveSync (EAS v2.5, v14 & v16.1) synchronization capabilities to [TbSync](https://github.com/jobisoft/TbSync/).
+If you want 16.1 on a server that still offers EAS 14, select **v16.1** manually.
 
-More information can be found in the [wiki](https://github.com/jobisoft/EAS-4-TbSync/wiki/About:-Provider-for-Exchange-ActiveSync) of this repository
+> EAS 14 support for Exchange Online [ended on 2026-03-01](https://techcommunity.microsoft.com/blog/exchange/exchange-online-activesync-device-support-update/4477997). Autodetect handles this on its own, since the server simply stops advertising 14.0.
+
+### EAS 16.1 notes
+
+Calendar, contacts and task synchronization and editing work on 16.1. The protocol differs from 14.0 in ways that are handled internally: no `TimeZone` element (UTC timestamps are used instead), no `UID` in item data, `Location` moved to the AirSyncBase namespace, and changes to a single occurrence of a recurring event are sent as an `InstanceId` change on the master item rather than as a separate item.
+
+## Meeting invitations (RSVP)
+
+**Accept / Tentative / Decline** on a received calendar invitation is sent back to the server with the EAS `MeetingResponse` command, so the organizer and the other attendees see your response. This works both for a whole meeting and for a **single occurrence** of a recurring one — answering one occurrence answers only that occurrence, matching Outlook.
+
+Previously the changed attendee status was pushed as an ordinary item change. Exchange interpreted that as *you* creating a new, self-organized meeting — duplicating the event and re-inviting everybody — and for a recurring meeting it silently did nothing at all. A freshly received, unanswered invitation is also no longer shown as already accepted (`ResponseType`/`AttendeeStatus` value `5` means *not responded*, not *accepted*).
+
+### After upgrading from 4.17.x or earlier
+
+Invitations that were already in your calendar were stored with the wrong participation status, and the add-on cannot tell from a local copy alone what the server really thinks. Those items are therefore left alone: they may still show as accepted when you never answered, and **responding to them does nothing** until they have been re-read from the server. Since ActiveSync only sends items that changed, they will not refresh on their own.
+
+To fix them, force a full resync of the calendar folder: in the TbSync account manager **uncheck** the Calendar folder, sync, then **re-check** it and sync again. Make sure no local changes are still pending first, because this replaces the calendar target.
+
+Invitations received after the upgrade are unaffected.
+
+### Expected behaviour that looks like a bug
+
+- **A declined meeting disappears from your calendar.** Exchange deletes it server-side once you decline and tells the client to remove it; Outlook behaves the same way. There is no setting to keep it.
+- **A partially answered recurring meeting shows as *Tentative* at the series level.** That is how Exchange represents a series where some occurrences are answered and others are not.
+
+### Known limitations
+
+- **EAS 2.5 cannot answer a single occurrence** — the protocol has no `InstanceId` for `MeetingResponse`. The response is not sent and the event log says so, rather than answering the whole series behind your back. Use a newer ActiveSync version, or respond in Outlook.
+- **Answering from the invitation e-mail** can leave a duplicate event in your calendar. Thunderbird's own iTIP handling records the response in a second, local copy of the event instead of the copy TbSync synced. That copy is detected and is *not* pushed to the server — your response is sent for the synced event, and the TbSync event log says so — but the stray local copy is left in place. Delete it manually if the event shows up twice.
+- **Editing a received invitation while responding to it** in the same sync interval sends only the response; the other edits are not pushed. Exchange does not accept item edits from attendees anyway.
+
+## Reporting problems
+
+Please include the Thunderbird version, the EAS version in use, the server type (Exchange Online / Exchange on-premises / Z-Push / …), and the relevant part of the TbSync event log (*Synchronization Settings → Open event log*). Raising the log level in TbSync's settings before reproducing makes the log far more useful.
 
 ## Want to add or fix a localization?
-To help translating this project, please visit [crowdin.com](https://crowdin.com/profile/jobisoft), where the localizations are managed. If you want to add a new language, just contact me and I will set it up.
 
+Localizations of the upstream project are managed on [crowdin.com](https://crowdin.com/profile/jobisoft). Strings that only exist in this fork can be contributed directly as a pull request against `_locales/`.
 
 ## External data sources
 
 * TbSync uses a [timezone mapping](https://github.com/mj1856/TimeZoneConverter/blob/master/src/TimeZoneConverter/Data/Mapping.csv.gz) provided by [Matt Johnson](https://github.com/mj1856)
 
+## Further reading
+
+More background on the provider can be found in the upstream [wiki](https://github.com/jobisoft/EAS-4-TbSync/wiki/About:-Provider-for-Exchange-ActiveSync).
 
 ## Icon sources and attributions
 

--- a/_locales/en-US/messages.json
+++ b/_locales/en-US/messages.json
@@ -314,6 +314,18 @@
     "status.ServerRejectedRequest": {
         "message": "The EAS Server rejected the last request."
     },
+    "status.MeetingResponse.2": {
+        "message": "The server rejected the response to this meeting invitation as invalid (status 2)"
+    },
+    "status.MeetingResponse.3": {
+        "message": "The server could not access the mailbox to record the response to this meeting invitation (status 3)"
+    },
+    "status.MeetingResponse.4": {
+        "message": "Server error while recording the response to this meeting invitation (status 4)"
+    },
+    "status.MeetingResponse.failed": {
+        "message": "The response to this meeting invitation could not be sent to the server, it will be retried on the next synchronization"
+    },
     "status.ServerRejectedSomeItems": {
         "message": "The EAS server did not accept ##replace.1## elements."
     },

--- a/content/includes/calendarsync.js
+++ b/content/includes/calendarsync.js
@@ -32,6 +32,15 @@ const ICAL = TbSync.lightning.ICAL;
 
 var Calendar = {
 
+    // iCal PARTSTAT -> EAS MeetingResponse UserResponse ([MS-ASCMD] 2.2.3.166.3).
+    // Note this is a *different* numeric scale from AttendeeStatus/ResponseType
+    // (eas.sync.MAP_EAS2TB.ATTENDEESTATUS): 1 = Accept, 2 = Tentative, 3 = Decline.
+    MAP_PARTSTAT2USERRESPONSE: { "ACCEPTED": "1", "TENTATIVE": "2", "DECLINED": "3" },
+
+    // iCal PARTSTAT -> EAS ResponseType, used to re-stamp X-EAS-ResponseType after
+    // the server accepted our MeetingResponse. Same scale as AttendeeStatus.
+    MAP_PARTSTAT2RESPONSETYPE: { "TENTATIVE": "2", "ACCEPTED": "3", "DECLINED": "4" },
+
     // --------------------------------------------------------------------------- //
     // EAS 16.1 Helper: Is this item an exception occurrence?
     // --------------------------------------------------------------------------- //
@@ -215,6 +224,38 @@ var Calendar = {
                     TbSync.eventlog.add("info", syncdata, "Attendee without required name and/or email found. Skipped.");
                 }
             }
+        }
+
+        // X-EAS-ResponseType is our record of the participation status the *server*
+        // last reported for the local user. eas.sync.Calendar.detectInvitationResponses
+        // compares it against the live PARTSTAT to tell an RSVP (Accept / Tentative /
+        // Decline) apart from an ordinary edit, so it has to mirror exactly what the
+        // attendee loop above just wrote into the self attendee - otherwise a plain
+        // edit of a received meeting looks like an RSVP, or a real RSVP goes unnoticed.
+        // X-EAS-SelfPartstat records the participation status we just wrote into the
+        // user's own attendee entry from server data. detectInvitationResponses compares
+        // the live PARTSTAT against it to tell an RSVP apart from an ordinary edit.
+        //
+        // Reading the attendee back through the very same getSelfAttendee lookup the
+        // detection uses makes the two agree by construction, so an ordinary edit of a
+        // received meeting can never be mistaken for an RSVP - not even on a server that
+        // reports ResponseType and AttendeeStatus inconsistently, or that omits
+        // ResponseType altogether (it is missing in 2.5 and optional elsewhere).
+        //
+        // Skipped for a partial Change, which carries no attendee data and must not be
+        // allowed to blank an existing marker.
+        if (data.Attendees) {
+            let self = Calendar.getSelfAttendee(item, syncdata);
+            item.setProperty("X-EAS-SelfPartstat",
+                (self && self.participationStatus) ? self.participationStatus : "NEEDS-ACTION");
+        }
+
+        // The server side UID is not our item.id - that one holds the EAS ServerId.
+        // Thunderbird's own itip engine keys invitations by UID, so keeping the real
+        // UID around is what lets matchInvitationResponse pair a duplicate item
+        // created by itip with the copy we already synced. Not sent in EAS 16.1.
+        if (data.UID && eas.tools.isString(data.UID)) {
+            item.setProperty("X-EAS-UID", data.UID);
         }
 
         if (data.OrganizerName && data.OrganizerEmail && eas.tools.isString(data.OrganizerEmail)) {
@@ -532,6 +573,281 @@ var Calendar = {
         //TbSync.dump("ALARM ("+i+")", [, alarms[i].related, alarms[i].repeat, alarms[i].repeatOffset, alarms[i].repeatDate, alarms[i].action].join("|"));
 
         return wbxml.getBytes();
+    },
+
+    // --------------------------------------------------------------------------- //
+    // MeetingResponse (RSVP) helpers
+    //
+    // Accepting / tentatively accepting / declining an invitation has to be sent
+    // with the EAS MeetingResponse command (eas.network.sendMeetingResponse), never
+    // as a generic Sync <Change> of the item: Exchange reads such a change as "the
+    // user created a new, self organized meeting", duplicating the event and
+    // re-inviting every attendee. Once it has our MeetingResponse the server updates
+    // the organizer's copy and notifies the attendees itself.
+    //
+    // Everything below decides from item data alone, no UI hook or call stack
+    // sniffing needed, and is only ever called for Calendar folders.
+    // --------------------------------------------------------------------------- //
+
+    nativeItem: function (tbItem) {
+        return tbItem instanceof TbSync.lightning.TbItem ? tbItem.nativeItem : tbItem;
+    },
+
+    // The attendee entry of the local EAS user, or null.
+    getSelfAttendee: function (tbItem, syncdata) {
+        let item = Calendar.nativeItem(tbItem);
+        let userEmail = syncdata.accountData.getAccountProperty("user");
+        if (!userEmail) return null;
+        userEmail = userEmail.toLowerCase();
+        for (let attendee of item.getAttendees()) {
+            if (!attendee.id) continue;
+            if (cal.email.removeMailTo(attendee.id).toLowerCase() == userEmail) return attendee;
+        }
+        return null;
+    },
+
+    // Bit 0x2 of EAS MeetingStatus: the meeting was received from someone else, so
+    // the user is an attendee and not the organizer. We only ever set this property
+    // from server data, which means its absence also tells us that an item never
+    // came from the server. Occurrences do not always carry their own copy, so fall
+    // back to the master they belong to.
+    isReceivedMeeting: function (tbItem) {
+        let item = Calendar.nativeItem(tbItem);
+        for (let candidate of [item, item.parentItem]) {
+            if (!candidate || typeof candidate.hasProperty != "function") continue;
+            if (!candidate.hasProperty("X-EAS-MeetingStatus")) continue;
+            return (parseInt(candidate.getProperty("X-EAS-MeetingStatus"), 10) & 0x2) != 0;
+        }
+        return false;
+    },
+
+    // Every pending RSVP on this item: the series level response, plus one per modified
+    // occurrence.
+    //
+    // A whole recurring series is a single EAS item (one ServerId), so a changelog entry
+    // always names the master. Thunderbird, however, records an Accept clicked on one
+    // occurrence by creating an *exception* for it - which is what accepting a recurring
+    // invitation from the calendar view always does. The exception inherits the master's
+    // X-EAS-SelfPartstat while its own PARTSTAT changes, so the mismatch is visible here
+    // and is answered with MeetingResponse's InstanceId element.
+    //
+    // Returns an array of { userResponse, partstat, instanceId, exceptionId }, where
+    // instanceId is null for a series level response and otherwise the UTC timestamp
+    // identifying the occurrence. Empty when nothing is a real Accept/Tentative/Decline
+    // transition - the caller then treats the change as an ordinary edit.
+    detectInvitationResponses: function (tbItem, syncdata) {
+        let item = Calendar.nativeItem(tbItem);
+        if (!Calendar.isReceivedMeeting(item)) return [];
+
+        // Called with a single occurrence rather than the master.
+        if (Calendar.isExceptionItem(item)) {
+            let response = Calendar.compareSelfPartstat(item, syncdata);
+            if (!response) return [];
+            response.instanceId = Calendar.meetingResponseInstanceId(item.recurrenceId);
+            response.exceptionId = item.recurrenceId;
+            return [response];
+        }
+
+        let responses = [];
+
+        let master = Calendar.compareSelfPartstat(item, syncdata);
+        if (master) {
+            master.instanceId = null;
+            master.exceptionId = null;
+            responses.push(master);
+        }
+
+        if (item.recurrenceInfo) {
+            for (let exceptionId of item.recurrenceInfo.getExceptionIds({})) {
+                let exception = item.recurrenceInfo.getExceptionFor(exceptionId);
+                if (!exception) continue;
+                let response = Calendar.compareSelfPartstat(exception, syncdata);
+                if (!response) continue;
+                response.instanceId = Calendar.meetingResponseInstanceId(exceptionId);
+                response.exceptionId = exceptionId;
+                responses.push(response);
+            }
+        }
+
+        return responses;
+    },
+
+    // The occurrence identifier for MeetingResponse's InstanceId element.
+    //
+    // Beware: this is NOT the same format as the AirSyncBase InstanceId used when
+    // pushing a 16.1 exception change (getWbxmlFromThunderbirdException above), even
+    // though both are "a UTC timestamp identifying an occurrence". MeetingResponseRequest
+    // .xsd restricts InstanceId to exactly 24 characters, i.e. the extended form
+    // 2026-08-10T07:45:00.000Z, while AirSyncBase uses the 16 character basic form
+    // 20260810T074500Z. Sending the basic form here makes Exchange reject the whole
+    // request with MeetingResponse Status 2 ("invalid meeting request"), which is
+    // indistinguishable from a genuinely stale meeting - so keep the two apart.
+    meetingResponseInstanceId: function (occurrenceId) {
+        return eas.tools.getIsoUtcString(occurrenceId, /* requireExtendedISO */ true);
+    },
+
+    // The marker comparison for one item or occurrence: is the live participation status
+    // of the user's own attendee entry a real RSVP transition away from what the server
+    // last told us? Returns { userResponse, partstat } or null (no self attendee, no
+    // change, a status MeetingResponse has no code for such as a reset to NEEDS-ACTION,
+    // or a status we cannot vouch for - see the marker check below).
+    compareSelfPartstat: function (item, syncdata) {
+        // X-EAS-SelfPartstat doubles as a version marker, and its absence must never be
+        // treated as "NEEDS-ACTION". Items synced by a build before this property
+        // existed carry a PARTSTAT produced by the old AttendeeStatus mapping, which
+        // turned "not responded" (5) into ACCEPTED. Comparing a live ACCEPTED against an
+        // assumed NEEDS-ACTION would look like a real Accept transition and fire a
+        // MeetingResponse for an invitation the user never answered - on any local write
+        // to the item, including Thunderbird acknowledging a reminder. So treat a
+        // missing marker as "server side status unknown" and stay out of the way until
+        // the item has been re-read from the server.
+        if (!item.hasProperty("X-EAS-SelfPartstat")) return null;
+        let lastPartstat = item.getProperty("X-EAS-SelfPartstat");
+
+        let attendee = Calendar.getSelfAttendee(item, syncdata);
+        if (!attendee) return null;
+
+        let currentPartstat = attendee.participationStatus ? attendee.participationStatus : "NEEDS-ACTION";
+        if (currentPartstat == lastPartstat) return null;
+
+        let userResponse = Calendar.MAP_PARTSTAT2USERRESPONSE[currentPartstat];
+        if (!userResponse) return null;
+
+        return { userResponse: userResponse, partstat: currentPartstat };
+    },
+
+    // Record the response once the server accepted our MeetingResponse, so the next
+    // sync pass does not detect and re-send it. Written via target.modifyItem, which
+    // pretags the changelog with a "_by_server" entry, so this write is not mistaken
+    // for yet another user change. exceptionId selects a single occurrence; pass null
+    // to stamp the series itself.
+    stampInvitationResponse: async function (tbItem, partstat, exceptionId, syncdata) {
+        let responseType = Calendar.MAP_PARTSTAT2RESPONSETYPE[partstat];
+        let newItem = tbItem.clone();
+
+        if (exceptionId) {
+            let master = Calendar.nativeItem(newItem);
+            if (!master.recurrenceInfo) return;
+            let exception = master.recurrenceInfo.getExceptionFor(exceptionId);
+            if (!exception) return;
+            let stamped = exception.clone();
+            stamped.setProperty("X-EAS-SelfPartstat", partstat);
+            if (responseType) stamped.setProperty("X-EAS-ResponseType", responseType);
+            master.recurrenceInfo.modifyException(stamped, true);
+        } else {
+            newItem.setProperty("X-EAS-SelfPartstat", partstat);
+            if (responseType) newItem.setProperty("X-EAS-ResponseType", responseType);
+        }
+
+        await syncdata.target.modifyItem(newItem, tbItem);
+    },
+
+    // Thunderbird's own itip engine answers an emailed invitation by looking for a
+    // calendar item carrying the *organizer's* UID. Our synced copy is stored under
+    // the EAS ServerId instead, so itip usually finds nothing and records the
+    // response in a second, parallel item that has none of our X-EAS-* markers.
+    // Pushed as a plain Add, Exchange turns that into a brand new self organized
+    // meeting: the event is duplicated and everybody is invited again.
+    //
+    // Recognise such an item and pair it with the copy we already synced, preferring
+    // an exact match on the server side UID stamped as X-EAS-UID (not available in
+    // EAS 16.1, which does not send UID) and falling back to subject + start + end.
+    //
+    // Returns { serverID, userResponse, partstat, exact } for the tracked item the
+    // response belongs to, or null when this really is a new meeting the user is
+    // organizing.
+    matchInvitationResponse: async function (candidateTbItem, syncdata) {
+        let candidate = Calendar.nativeItem(candidateTbItem);
+
+        // Everything we ever pulled from the server carries X-EAS-MeetingStatus, so
+        // its presence means this is not an itip created item and must not be matched.
+        if (candidate.hasProperty("X-EAS-MeetingStatus")) return null;
+        if (Calendar.isExceptionItem(candidate)) return null;
+        if (!candidate.startDate || !candidate.endDate) return null;
+
+        // Without an actual response this is just a new meeting the user created.
+        let attendee = Calendar.getSelfAttendee(candidate, syncdata);
+        if (!attendee) return null;
+        let partstat = attendee.participationStatus;
+        let userResponse = Calendar.MAP_PARTSTAT2USERRESPONSE[partstat];
+        if (!userResponse) return null;
+
+        let candidateTitle = candidate.title ? candidate.title.trim() : "";
+        let items = await Calendar.getItemsInRange(syncdata.target.calendar, candidate.startDate, candidate.endDate, syncdata);
+
+        let fuzzyMatch = null;
+        for (let existing of items) {
+            if (existing.id == candidate.id) continue;
+            if (!Calendar.isReceivedMeeting(existing)) continue;
+
+            // Exact: the UID of the invitation, which is also the id itip gave the
+            // item it created.
+            if (candidate.id && existing.hasProperty("X-EAS-UID") && existing.getProperty("X-EAS-UID") == candidate.id) {
+                return { serverID: existing.id, userResponse: userResponse, partstat: partstat, exact: true };
+            }
+
+            if (fuzzyMatch === null
+                && candidateTitle
+                && existing.title && existing.title.trim() == candidateTitle
+                && existing.startDate && existing.startDate.compare(candidate.startDate) == 0
+                && existing.endDate && existing.endDate.compare(candidate.endDate) == 0) {
+                // do not return yet, an exact UID match further down the list wins
+                fuzzyMatch = existing.id;
+            }
+        }
+
+        if (fuzzyMatch) {
+            return { serverID: fuzzyMatch, userResponse: userResponse, partstat: partstat, exact: false };
+        }
+        return null;
+    },
+
+    // Master events of a calendar overlapping [rangeStart, rangeEnd], widened by a
+    // day on each side to stay clear of timezone and all-day edge cases. Thunderbird
+    // moved calICalendar.getItems from a callback to an array to a ReadableStream
+    // over the years, so detect the shape instead of pinning one - and never let a
+    // future change of that API break the sync: an empty result only means we do not
+    // recognize a duplicate, it does not lose any data.
+    getItemsInRange: async function (calendar, rangeStart, rangeEnd, syncdata) {
+        try {
+            let oneDayBack = cal.createDuration();
+            oneDayBack.inSeconds = -86400;
+            let oneDayAhead = cal.createDuration();
+            oneDayAhead.inSeconds = 86400;
+
+            let from = rangeStart.clone();
+            from.addDuration(oneDayBack);
+            let to = rangeEnd.clone();
+            to.addDuration(oneDayAhead);
+
+            // no ITEM_FILTER_CLASS_OCCURRENCES, we only want the master items
+            let filter = Components.interfaces.calICalendar.ITEM_FILTER_TYPE_EVENT;
+
+            if (typeof calendar.getItemsAsArray == "function") {
+                return await calendar.getItemsAsArray(filter, 0, from, to);
+            }
+
+            let result = calendar.getItems(filter, 0, from, to);
+            if (result && typeof result.getReader == "function") {
+                let items = [];
+                let reader = result.getReader();
+                for (; ;) {
+                    let chunk = await reader.read();
+                    if (chunk.done) break;
+                    if (Array.isArray(chunk.value)) items.push(...chunk.value);
+                    else if (chunk.value) items.push(chunk.value);
+                }
+                return items;
+            }
+
+            let resolved = await result;
+            return Array.isArray(resolved) ? resolved : [];
+        } catch (e) {
+            TbSync.eventlog.add("info", syncdata ? syncdata.eventLogInfo : null,
+                "Could not enumerate calendar items, cannot check whether this is a duplicate invitation response.",
+                e.message);
+            return [];
+        }
     }
 }
 // Export Calendar object so sync.js can use it

--- a/content/includes/network.js
+++ b/content/includes/network.js
@@ -1045,6 +1045,94 @@ var network = {
         }
     },
 
+    // ---------------------------------------------------------------------------
+    // EAS MeetingResponse - [MS-ASCMD] 2.2.2.10 / 3.1.5.5
+    //
+    // Tells the server that the user accepted, tentatively accepted or declined a
+    // meeting invitation. This is the protocol correct channel for an RSVP and it
+    // must be used *instead* of pushing the changed attendee status back as a
+    // generic Sync <Change>: Exchange reads such a change as "the user created a
+    // new, self organized meeting", which duplicates the event and re-broadcasts
+    // invitations to every attendee. Once the server has our MeetingResponse it
+    // updates the organizer's copy and notifies the attendees itself.
+    //
+    // Returns
+    //   { success: true,  status: "" }           on Status 1
+    //   { success: false, status: <statusType> } on a soft server error, e.g.
+    //                                           "MeetingResponse.2" (invalid
+    //                                           meeting request), ".3" (mailbox
+    //                                           error) or ".4" (server error)
+    //   { success: false, status: null }         on a transport error or a
+    //                                           response without any data
+    // Hard errors (bad policy key, access denied, ...) are still thrown by
+    // checkStatus, exactly as for every other command.
+    // ---------------------------------------------------------------------------
+    sendMeetingResponse: async function (syncData, serverID, userResponse, instanceId = null) {
+        let collectionId = syncData.currentFolderData.getFolderProperty("serverID");
+        if (!collectionId || !serverID || !userResponse) {
+            return { success: false, status: null };
+        }
+
+        // BUILD WBXML
+        let wbxml = eas.wbxmltools.createWBXML();
+        wbxml.switchpage("MeetingResponse");
+        wbxml.otag("MeetingResponse");
+        wbxml.otag("Request");
+        wbxml.atag("UserResponse", String(userResponse));
+        // CollectionId and RequestId are tokens of the MeetingResponse codepage
+        // itself (0x06 / 0x08). They are *not* the AirSync CollectionId, so no
+        // switchpage is wanted here.
+        wbxml.atag("CollectionId", collectionId);
+        wbxml.atag("RequestId", serverID);
+        // A whole recurring series is one EAS item, so responding to a single
+        // occurrence is expressed by naming that instance rather than by addressing a
+        // different item. InstanceId is the occurrence's original start time in UTC and
+        // follows RequestId in the schema. Not available in EAS 2.5, whose callers must
+        // not pass one.
+        //
+        // MeetingResponseRequest.xsd restricts this to exactly 24 characters (the
+        // extended form 2026-08-10T07:45:00.000Z) - unlike the AirSyncBase InstanceId,
+        // which is the 16 character basic form. Getting it wrong is answered with
+        // Status 2, so refuse to send a malformed value rather than have the server
+        // reject the response as an invalid meeting.
+        if (instanceId) {
+            if (String(instanceId).length != 24) {
+                TbSync.eventlog.add("warning", syncData.eventLogInfo,
+                    "Not sending a meeting response for a single occurrence: InstanceId <" + instanceId + "> is not the 24 character format the protocol requires.",
+                    serverID);
+                return { success: false, status: null };
+            }
+            wbxml.atag("InstanceId", instanceId);
+        }
+        wbxml.ctag(); //Request
+        wbxml.ctag(); //MeetingResponse
+
+        //SEND REQUEST (re-using the localchanges sync states, this is a push)
+        syncData.setSyncState("send.request.localchanges");
+        let response = await eas.network.sendRequest(wbxml.getBytes(), "MeetingResponse", syncData, /* allowSoftFail */ true);
+
+        //VALIDATE RESPONSE
+        syncData.setSyncState("eval.response.localchanges");
+        let wbxmlData = eas.network.getDataFromResponse(response, eas.flags.allowEmptyResponse);
+        if (wbxmlData === null) {
+            return { success: false, status: null };
+        }
+
+        // A response without any status at all is not worth aborting the sync for -
+        // treat it like a transport error and let the caller retry on the next run,
+        // instead of letting checkStatus throw on the missing field.
+        if (!eas.xmltools.hasWbxmlDataField(wbxmlData, "MeetingResponse.Result.Status")
+            && !eas.xmltools.hasWbxmlDataField(wbxmlData, "MeetingResponse.Status")) {
+            return { success: false, status: null };
+        }
+
+        // Let checkStatus deal with the global status codes (provisioning, access
+        // denied, ...) but soft fail on the MeetingResponse specific ones, so a
+        // single rejected invitation does not abort the whole sync.
+        let errorcause = eas.network.checkStatus(syncData, wbxmlData, "MeetingResponse.Result.Status", "", true);
+        return { success: (errorcause === ""), status: errorcause };
+    },
+
     getUserInfo: async function (syncData) {
         if (!syncData.accountData.getAccountProperty("allowedEasCommands").split(",").includes("Settings")) {
             return;

--- a/content/includes/sync.js
+++ b/content/includes/sync.js
@@ -875,14 +875,36 @@ var sync = {
 
             if (invitation.duplicateOf) {
                 // The changelog entry belonged to the duplicate Thunderbird's itip engine
-                // created, not to the synced copy the response was sent for. Unless we could
-                // match the server side UID the pairing is content based, so the duplicate is
-                // deliberately not deleted behind the user's back - we only stop pushing it.
-                TbSync.eventlog.add("warning", syncData.eventLogInfo,
+                // created, not to the synced copy the response was sent for.
+                //
+                // On an exact match we know for certain the two are the same meeting: the
+                // duplicate is named with the invitation's UID and we matched it against the
+                // very same value stamped as X-EAS-UID. Nothing of the user's is lost by
+                // removing it - the response is already recorded on the synced copy, which
+                // stays in the calendar - so clean it up instead of leaving a visible
+                // duplicate behind. Deleted through the target so the changelog is pretagged
+                // "_by_server" and this never goes out as a user delete of a ServerId the
+                // server does not know.
+                //
+                // A subject+start+end match is only a heuristic, so that case is still left
+                // alone: we stop pushing it, but deleting a user's calendar item on a guess
+                // is not something to do behind their back.
+                let removed = false;
+                if (invitation.exactMatch) {
+                    let duplicateItem = await syncData.target.getItem(invitation.itemId);
+                    if (duplicateItem) {
+                        await syncData.target.deleteItem(duplicateItem);
+                        syncData.target.removeItemFromChangeLog(invitation.itemId);
+                        removed = true;
+                    }
+                }
+
+                TbSync.eventlog.add("info", syncData.eventLogInfo,
                     "Sent a meeting response for the already synchronized invitation <" + invitation.duplicateOf + ">, "
-                    + "because Thunderbird recorded the response in a second, local copy of the event"
-                    + (invitation.exactMatch ? "" : " (matched by subject and time)")
-                    + ". That copy was not sent to the server, but it is still in your calendar - delete it there if the event shows up twice.",
+                    + "because Thunderbird recorded the response in a second, local copy of the event. "
+                    + (removed
+                        ? "That copy matched the invitation exactly and has been removed from your calendar."
+                        : "That copy was matched by subject and time only, so it was not sent to the server but is still in your calendar - delete it there if the event shows up twice."),
                     invitation.itemId);
             }
         }

--- a/content/includes/sync.js
+++ b/content/includes/sync.js
@@ -473,6 +473,19 @@ var sync = {
             let addedItems = {};
             let sendItems = [];
 
+            // An RSVP (Accept / Tentative / Decline of a meeting invitation) must be sent
+            // with the EAS MeetingResponse command instead of being pushed as a generic
+            // item change - see eas.network.sendMeetingResponse. MeetingResponse is its
+            // own EAS command, so these are collected here and sent separately below.
+            let invitationResponses = [];
+            // MeetingResponse is mandatory since EAS 2.5, but only reroute when the server
+            // did not explicitly tell us otherwise: an empty list means the OPTIONS probe
+            // never returned MS-ASProtocolCommands, and falling back to a generic push
+            // would silently re-introduce the duplicate-meeting bug this avoids.
+            let allowedCommands = syncData.accountData.getAccountProperty("allowedEasCommands");
+            let canSendMeetingResponse = (syncData.type == "Calendar") && !!eas.sync.Calendar
+                && (!allowedCommands || allowedCommands.split(",").includes("MeetingResponse"));
+
             // BUILD WBXML
             let wbxml = eas.wbxmltools.createWBXML();
             wbxml.otag("Sync");
@@ -497,6 +510,31 @@ var sync = {
                                 TbSync.eventlog.add("warning", syncData.eventLogInfo, "MailingListNotSupportedItemSkipped");
                                 syncData.target.removeItemFromChangeLog(changes[i].itemId);
                             } else if (syncData.type == eas.sync.getEasItemType(item)) {
+
+                                // Thunderbird's itip engine may have answered an emailed invitation
+                                // by creating a second, parallel item instead of editing the copy we
+                                // already synced. Send the response for the synced item and drop this
+                                // Add, which Exchange would otherwise turn into a new, self organized
+                                // meeting - duplicating the event and re-inviting everybody.
+                                let duplicate = canSendMeetingResponse
+                                    ? await eas.sync.Calendar.matchInvitationResponse(item, syncData)
+                                    : null;
+                                if (duplicate) {
+                                    invitationResponses.push({
+                                        itemId: changes[i].itemId,
+                                        serverID: duplicate.serverID,
+                                        duplicateOf: duplicate.serverID,
+                                        exactMatch: duplicate.exact,
+                                        // a duplicate created by itip always answers the series
+                                        responses: [{
+                                            userResponse: duplicate.userResponse,
+                                            partstat: duplicate.partstat,
+                                            instanceId: null,
+                                            exceptionId: null
+                                        }]
+                                    });
+                                    break;
+                                }
 
                                 let asversion = syncData.accountData.getAccountProperty("asversion");
 
@@ -557,6 +595,39 @@ var sync = {
                         if (item) {
                             //filter out bad object types for this folder
                             if (syncData.type == eas.sync.getEasItemType(item)) {
+
+                                // Clicking Accept / Tentative / Decline on a received invitation only
+                                // flips the participation status of our own attendee entry - on the
+                                // series, or on a single occurrence, which Thunderbird records as an
+                                // exception. That is an RSVP, not an ordinary edit, and has to go out
+                                // as a MeetingResponse. Pushing it as a Sync <Change> tells the server
+                                // nothing (we deliberately never send AttendeeStatus), so the response
+                                // would be silently lost.
+                                let detected = (syncData.type == "Calendar" && eas.sync.Calendar)
+                                    ? eas.sync.Calendar.detectInvitationResponses(item, syncData)
+                                    : [];
+                                if (detected.length) {
+                                    if (canSendMeetingResponse) {
+                                        invitationResponses.push({
+                                            itemId: changes[i].itemId,
+                                            serverID: changes[i].itemId,
+                                            responses: detected
+                                        });
+                                    } else {
+                                        // Never fall through to the generic push here: it cannot carry
+                                        // the response, so it would look like success while the
+                                        // organizer is never told. Drop the entry (so we do not retry
+                                        // forever) and say so.
+                                        TbSync.eventlog.add("warning", syncData.eventLogInfo,
+                                            "Cannot send your response to this meeting invitation: the server does not offer the MeetingResponse command. "
+                                            + "Your local status was kept, but the organizer has not been informed - please respond in Outlook or Outlook Web instead.",
+                                            changes[i].itemId);
+                                        syncData.target.removeItemFromChangeLog(changes[i].itemId);
+                                        syncData.progressData.inc();
+                                    }
+                                    break;
+                                }
+
                                 let asversion = syncData.accountData.getAccountProperty("asversion");
                                 let isException = eas.sync.Calendar ? eas.sync.Calendar.isExceptionItem(item) : false;
 
@@ -637,6 +708,16 @@ var sync = {
             wbxml.ctag(); //Collections
             wbxml.ctag(); //Sync
 
+            // MeetingResponse is a separate EAS command, so any detected RSVP goes out on
+            // its own, ahead of the Sync request built above.
+            let sentInvitationResponse = false;
+            if (invitationResponses.length > 0) {
+                sentInvitationResponse = await eas.sync.sendInvitationResponses(syncData, invitationResponses);
+                // A MeetingResponse makes the server update the item (and the organizer's
+                // copy), so the caller has to wait for the delayed ack just as it does for
+                // an ordinary local change.
+                if (sentInvitationResponse) sendChanges = true;
+            }
 
             if (c > 0) { //if there was at least one actual local change, send request
                 sendChanges = true;
@@ -709,11 +790,13 @@ var sync = {
                     eas.network.updateSynckey(syncData, wbxmlData);
                 }
 
-            } else if (e == 0) { //if there was no local change and also no error (which will not happen twice) finish
+            } else if (e == 0 && !sentInvitationResponse) { //if there was no local change and also no error (which will not happen twice) finish
 
                 done = true;
 
             }
+            //if we did send RSVPs, their changelog entries are gone now - loop once more, so
+            //any remaining changes beyond this batch still get pushed during this run
 
         } while (!done);
 
@@ -722,6 +805,89 @@ var sync = {
             throw eas.sync.finish("warning", "ServerRejectedSomeItems::" + syncData.failedItems.length);
         }
         return sendChanges;
+    },
+
+
+    // Send the RSVPs collected by sendLocalChanges as EAS MeetingResponse commands
+    // (see eas.sync.Calendar.detectInvitationResponses / matchInvitationResponse for
+    // how they are recognised). Returns true if the server accepted at least one.
+    sendInvitationResponses: async function (syncData, invitationResponses) {
+        let anySent = false;
+        let asversion = syncData.accountData.getAccountProperty("asversion");
+
+        for (let invitation of invitationResponses) {
+            if (syncData.failedItems.includes(invitation.itemId)) continue;
+
+            // One item can carry several responses: the series plus any occurrence the
+            // user answered individually. Each needs its own MeetingResponse command.
+            let allSent = true;
+            let lastStatus = null;
+
+            for (let response of invitation.responses) {
+                if (response.instanceId && asversion == "2.5") {
+                    // EAS 2.5 has no InstanceId, so a single occurrence cannot be
+                    // addressed at all. Do not silently answer the whole series instead.
+                    TbSync.eventlog.add("warning", syncData.eventLogInfo,
+                        "Cannot send your response to a single occurrence of this recurring meeting: EAS 2.5 does not support it. "
+                        + "Please respond in Outlook or Outlook Web, or select a newer ActiveSync version.",
+                        invitation.itemId);
+                    continue;
+                }
+
+                let result = await eas.network.sendMeetingResponse(
+                    syncData, invitation.serverID, response.userResponse, response.instanceId);
+
+                if (!result.success) {
+                    allSent = false;
+                    lastStatus = result.status;
+                    continue;
+                }
+
+                anySent = true;
+
+                // Re-fetch each time: stamping rewrites the item, so a stale copy would
+                // clobber the previous stamp when several responses share one item.
+                let trackedItem = await syncData.target.getItem(invitation.serverID);
+                if (trackedItem) {
+                    await eas.sync.Calendar.stampInvitationResponse(
+                        trackedItem, response.partstat, response.exceptionId, syncData);
+                }
+            }
+
+            if (!allSent) {
+                // Keep the changelog entry (moved to the end of the log) so the response is
+                // retried on the next sync run instead of being silently lost. Responses
+                // that did succeed are already stamped, so they are not resent.
+                let failedItem = await syncData.target.getItem(invitation.itemId);
+                eas.sync.updateFailedItems(
+                    syncData,
+                    lastStatus ? lastStatus : "MeetingResponse.failed",
+                    invitation.itemId,
+                    failedItem ? failedItem.toString() : invitation.itemId);
+                continue;
+            }
+
+            // Everything is recorded server side now, so the local change no longer needs
+            // pushing. The stamping above ran with the entry still present, which is
+            // harmless: modifyItem pretags "_by_server", and this removal covers it.
+            syncData.target.removeItemFromChangeLog(invitation.itemId);
+            syncData.progressData.inc();
+
+            if (invitation.duplicateOf) {
+                // The changelog entry belonged to the duplicate Thunderbird's itip engine
+                // created, not to the synced copy the response was sent for. Unless we could
+                // match the server side UID the pairing is content based, so the duplicate is
+                // deliberately not deleted behind the user's back - we only stop pushing it.
+                TbSync.eventlog.add("warning", syncData.eventLogInfo,
+                    "Sent a meeting response for the already synchronized invitation <" + invitation.duplicateOf + ">, "
+                    + "because Thunderbird recorded the response in a second, local copy of the event"
+                    + (invitation.exactMatch ? "" : " (matched by subject and time)")
+                    + ". That copy was not sent to the server, but it is still in your calendar - delete it there if the event shows up twice.",
+                    invitation.itemId);
+            }
+        }
+
+        return anySent;
     },
 
 
@@ -1098,7 +1264,12 @@ var sync = {
         //EAS BusyStatus:  0 = Free  |  1 = Tentative  |  2 = Busy  |  3 = Work  |  4 = Elsewhere
         BusyStatus: { "0": "TRANSPARENT", "1": "unset", "2": "OPAQUE", "3": "OPAQUE", "4": "OPAQUE" }, //to TRANSP
         //EAS AttendeeStatus: 0 =Response unknown (but needed) |  2 = Tentative  |  3 = Accept  |  4 = Decline  |  5 = Not responded (and not needed) || 1 = Organizer in ResponseType
-        ATTENDEESTATUS: { "0": "NEEDS-ACTION", "1": "Orga", "2": "TENTATIVE", "3": "ACCEPTED", "4": "DECLINED", "5": "ACCEPTED" },
+        //5 is NOT "accepted": per MS-ASCAL it means "Not responded" on both AttendeeStatus and
+        //ResponseType, and a freshly sent, completely unanswered invitation arrives with 5.
+        //Mapping it to ACCEPTED made every brand new invitation look pre-accepted, and it also
+        //masked real Accept clicks from eas.sync.Calendar.detectInvitationResponses, because
+        //"already ACCEPTED" == "now ACCEPTED" meant no MeetingResponse was ever sent.
+        ATTENDEESTATUS: { "0": "NEEDS-ACTION", "1": "Orga", "2": "TENTATIVE", "3": "ACCEPTED", "4": "DECLINED", "5": "NEEDS-ACTION" },
     },
 
     MAP_TB2EAS: {

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
   },
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "4.18.3",
+  "version": "4.18.4",
   "author": "John Bieling",
   "homepage_url": "https://github.com/NielBuys/EAS-4-TbSync",
   "default_locale": "en-US",

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
   },
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "4.17.8",
+  "version": "4.18.3",
   "author": "John Bieling",
   "homepage_url": "https://github.com/NielBuys/EAS-4-TbSync",
   "default_locale": "en-US",


### PR DESCRIPTION
## Summary

Accepting or declining a meeting invitation never reached Exchange. `MeetingResponse` was defined only as a WBXML codepage token (`wbxmltools.js`) and was never built or sent, so the attendee status change was swept up by the generic changelog and pushed as an ordinary `Sync <Change>` — which tells the server nothing, since we deliberately never send `AttendeeStatus`. For a recurring meeting it did nothing at all, silently.

This implements the command for a whole meeting and for a **single occurrence** of a recurring one.

Re-derived for the v4 line. Upstream's equivalent ([jobisoft#329](https://github.com/jobisoft/EAS-4-TbSync/pull/329)) targets the v5 rewrite and is not portable: v5 keys items by the server `UID` with a separate serverID↔itemId index, whereas in v4 the Thunderbird item id **is** the EAS ServerId. Its central fix and the adopt-in-place logic built on it therefore cannot cross over. Upstream also left per-occurrence responses out of scope.

## What changed

- **`network.js`** — `sendMeetingResponse()` builds and sends the command ([MS-ASCMD] §2.2.2.10 / §3.1.5.5). Global statuses still go through `checkStatus`; the MeetingResponse-specific ones (2/3/4) soft-fail so a single rejected invitation cannot abort a sync.
- **`calendarsync.js`** — `detectInvitationResponses()` recognises an RSVP purely from item data (live self-attendee `PARTSTAT` vs. the status the server last reported), covering the series **and** each modified occurrence. `matchInvitationResponse()` catches Thunderbird's iTIP engine recording a response in a duplicate local item rather than the synced copy, matching on the server `UID` stamped as `X-EAS-UID` and falling back to subject + start + end.
- **`sync.js`** — routes detected RSVPs out of `sendLocalChanges` into `sendInvitationResponses()`, one command per response, clearing the changelog only when all succeed and stamping each onto the right series/occurrence. On an **exact** UID match the stray iTIP duplicate is deleted automatically; a fuzzy match is left alone and logged.
- **`ATTENDEESTATUS[5]`** fixed from `ACCEPTED` to `NEEDS-ACTION`. Per MS-ASCAL, `5` is *not responded* on both `AttendeeStatus` and `ResponseType`, and a fresh unanswered invitation arrives with `5`. The old mapping made every new invitation look pre-accepted and masked real Accept clicks from detection.

### Three subtleties worth knowing

**The two `InstanceId` elements are not the same format.** `MeetingResponseRequest.xsd` restricts `InstanceId` to exactly **24** characters (`2026-08-10T07:45:00.000Z`), while the AirSyncBase `InstanceId` used for 16.1 exception edits is the **16**-character basic form (`20260810T074500Z`). Sending the basic form is answered with `Status 2` ("invalid meeting request"), indistinguishable from a genuinely stale meeting. Both call sites carry comments, plus a length guard that refuses to send a malformed value.

**`X-EAS-SelfPartstat` doubles as a version marker.** Its absence means "server-side status unknown" and detection backs off entirely. Items written by an older build carry a `PARTSTAT` produced by the old `AttendeeStatus` mapping, so comparing against them would fire a `MeetingResponse` for an invitation the user never answered — on *any* local write, including Thunderbird acknowledging a reminder.

**The organizer is notified by Thunderbird, not by us.** On 16.x the server only emails the organizer if the request carries `SendResponse`, which we deliberately omit — Thunderbird's own iTIP handling already sends the reply over SMTP, so adding it would notify the organizer twice. Confirmed on a cross-tenant test: `MeetingResponse` returned `Status 1` and the organizer's copy still showed "Didn't respond" until the iTIP reply arrived.

## Upgrade note

Invitations already in the calendar keep the wrong status and are deliberately left alone; responding to them does nothing until they are re-read from the server, and ActiveSync only resends items that changed. A full folder resync corrects them. Documented in the README.

## Test plan

Verified end-to-end against Exchange Online on EAS 16.1, with the local calendar store inspected directly rather than relying on the UI:

- [x] **Per-occurrence Accept** of a recurring meeting — `MeetingResponse` with `InstanceId`, `Status=1`, accepted in Outlook Web, marker stamped on that occurrence only; series and other occurrences untouched.
- [x] **Series-level Decline** from `NEEDS-ACTION` — `UserResponse=3`, no `InstanceId`; Exchange accepted it and removed the meeting itself (confirmed via a `deleted_by_server` changelog entry, i.e. the server drove the delete rather than a local `Delete` being pushed).
- [x] **Decline after Accept** (`ACCEPTED` → `DECLINED`) — same path, exercising a transition away from an existing response rather than from "not responded".
- [x] **Cross-tenant Accept** (organizer on a personal Outlook.com account) — `Status=1`, status recorded server-side, iTIP reply delivered to the organizer.
- [x] **Accept from the invitation e-mail** (the `matchInvitationResponse` duplicate path) — exact `X-EAS-UID` match, response sent for the synced copy, duplicate never pushed and now auto-removed, leaving exactly one calendar entry and one notification e-mail.
- [x] **Negative case: a genuinely new event is not swallowed** — an event created locally (no attendees, no `X-EAS-MeetingStatus`) still pushes as a normal `Add` and receives a real EAS ServerId, confirming `matchInvitationResponse` declines to match it. Editing it likewise pushes as a normal `Change`.
- [x] No repeat send on subsequent syncs (marker matches `PARTSTAT`, changelog clean).
- [x] Failed response preserved and retried rather than lost — confirmed by the `Status 2` `InstanceId` failure, which retried successfully once the format was fixed.

Deliberately not tested, with reasoning:

- **Tentative (`UserResponse=2`)** — the same function as Accept and Decline with one constant different (`MAP_PARTSTAT2USERRESPONSE["TENTATIVE"]`), no separate branch. Accept (`1`) and Decline (`3`) both passing demonstrates the plumbing and that the two numeric scales are not crossed.
- **Tasks/contacts regression** — established by inspection instead. The whole `sync.js` diff deletes exactly one line (`e == 0` becomes `e == 0 && !sentInvitationResponse`); everything else is additive. `invitationResponses` can only be filled from two sites, both gated on `syncData.type == "Calendar"`, so `sentInvitationResponse` is always `false` for Tasks and Contacts and that condition reduces to the original. `tasksync.js` and `contactsync.js` are untouched.

### Known gaps

- The pull phase runs before the push phase, so TbSync's existing "server wins" conflict policy can discard a pending response if the server sends a `Change` for the same item in that sync — the RSVP is then silently lost and has to be clicked again. Pre-existing policy, newly reachable from this feature.
- The subject + start + end fallback in `matchInvitationResponse` has not been exercised; both duplicate tests matched exactly on the UID. It is deliberately conservative (never auto-deletes) for that reason.
- Only EAS 16.1 was exercised. The 2.5 per-occurrence guard and the 14.x paths are reasoned, not observed.
- Responding to several occurrences before a single sync exercises the re-fetch-per-response logic; reasoned, not run.

## Out of scope

- Keeping a struck-through copy of a declined meeting. Exchange deletes it server-side and instructs the client to remove it; Outlook behaves identically. Retaining a local ghost would mean deliberately ignoring the server's `Delete`.
- Batching several responses into one request (currently one request per response).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
